### PR TITLE
Inserido dependencia de bStatus e classes de testes do bug skip night

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+/.idea/
 /target/
 copy-jar-to-server.bat
 
 /src/main/resources/todo.txt
+/dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,16 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>me.reratos.timehandler</groupId>
 	<artifactId>TimeHandler</artifactId>
-	<version>1.4.3-beta</version>
+	<version>1.4.4-beta</version>
 	
 	<properties>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
-		<spigotmc.version>1.16.2-R0.1-SNAPSHOT</spigotmc.version>
+		<spigotmc.version>1.16.3-R0.1-SNAPSHOT</spigotmc.version>
+		<project.build.sourceEncoding>windows-1252</project.build.sourceEncoding>
 	</properties>
 	
 	<build>
@@ -35,6 +38,58 @@
 	                <target>1.8</target>
 	            </configuration>
 	        </plugin>
+
+			<!-- Configuration for bStats Metrics -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<relocations>
+						<relocation>
+							<pattern>org.bstats</pattern>
+							<shadedPattern>me.reratos.timehandler</shadedPattern>
+						</relocation>
+					</relocations>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.2</version>
+				<configuration>
+					<!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
+					<skip>true</skip>
+					<!-- Show 100% of the lines from the stack trace (doesn't work) -->
+					<trimStackTrace>false</trimStackTrace>
+				</configuration>
+				<executions>
+					<execution>
+						<id>unit-tests</id>
+						<phase>test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<!-- Never skip running the tests when the test phase is invoked -->
+							<skip>false</skip>
+							<includes>
+								<!-- Include unit tests within integration-test phase. -->
+								<include>**/*Test.java</include>
+							</includes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
   
@@ -44,6 +99,12 @@
 	        <id>spigot-repo</id>
 	        <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
 	    </repository>
+	    
+	    <!-- This adds the bStats repository -->
+	    <repository>
+			<id>CodeMC</id>
+			<url>https://repo.codemc.org/repository/maven-public/</url>
+		</repository>
 	</repositories>
 	
 	<dependencies>
@@ -62,7 +123,15 @@
 			<version>1.15.2-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>-->
-		
+
+		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.7.0</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- https://mvnrepository.com/artifact/org.easymock/easymock -->
 		<dependency>
 		    <groupId>org.easymock</groupId>
@@ -75,9 +144,25 @@
 		<dependency>
 		    <groupId>com.github.seeseemelk</groupId>
 		    <artifactId>MockBukkit-v1.16</artifactId>
-		    <version>0.13.0</version>
+		    <version>0.15.0</version>
 		    <scope>test</scope>
 		</dependency>
-		
+
+		<!-- https://repo.codemc.io/service/rest/repository/browse/maven-public/ -->
+		<dependency>
+			<groupId>org.bstats</groupId>
+			<artifactId>bstats-bukkit</artifactId>
+			<version>1.7</version>
+			<scope>compile</scope>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
+		<dependency>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-surefire-plugin</artifactId>
+			<version>2.22.2</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/src/main/java/me/reratos/timehandler/events/PlayerListener.java
+++ b/src/main/java/me/reratos/timehandler/events/PlayerListener.java
@@ -31,7 +31,6 @@ public class PlayerListener implements Listener {
 			int dif = (int) (24000 - w.getTime());
 			TimeSkipEvent timeSkipEvent = new TimeSkipEvent(w, SkipReason.NIGHT_SKIP, dif);
 			Bukkit.getPluginManager().callEvent(timeSkipEvent);
-			
 		}
 	}
 }

--- a/src/main/java/me/reratos/timehandler/utils/Constants.java
+++ b/src/main/java/me/reratos/timehandler/utils/Constants.java
@@ -16,6 +16,7 @@ public final class Constants {
 	public final static String FILE_NAME_CONFIG_YML 		= "config.yml";
 	public final static String FILE_NAME_WORLDS_CONFIG_YML 	= "worldsConfig.yml";
 	public final static String RESOURCE_ID 					= "83803";
+	public final static int METRICS_PLUGIN_ID				= 9216;
 	
 	public final static String URL_PLUGIN = "https://www.spigotmc.org/resources/timehandler.83803/";
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,6 @@
 name: TimeHandler
-version: 1.4.3-beta
+version: 1.4.4-beta
+api-version: 1.13
 main: me.reratos.timehandler.TimeHandler
 author: Relry
 database: false

--- a/src/test/java/me/reratos/timehandler/CommandsTest.java
+++ b/src/test/java/me/reratos/timehandler/CommandsTest.java
@@ -9,13 +9,8 @@ import java.util.Set;
 
 import org.bukkit.World;
 import org.bukkit.command.Command;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
@@ -36,7 +31,7 @@ class CommandsTest {
 	@BeforeAll
 	public static void setUp() {
 	    server = MockBukkit.mock();
-	    timeHandler = (TimeHandler) MockBukkit.load(TimeHandler.class);
+	    timeHandler = MockBukkit.load(TimeHandler.class);
 	    
 	    wMock = new WorldMock();
 	    wMock.setName("test");
@@ -48,33 +43,35 @@ class CommandsTest {
 	public static void tearDown() {
 		try {
 			MockBukkit.unmock();
-		} catch (AsyncTaskException e) {
+		} catch (AsyncTaskException ignored) {
 		}
 	}
 
 	/* ==== TEST /TIMEHANDLER HELP ==== */
-	@Test
-	@Disabled ("Unimplemented hasPermission")
-	void testCommandTimehandlerHelp_ServerArgs_1() {
-		boolean condition = false;
-		String label = "timehandler";
-		String args[] = {"help"};
-		Command command = server.getPluginCommand(label);
-		
-		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
-		
-		assertTrue(condition);
-	}
+//	@Test
+//	@Disabled ("Unimplemented hasPermission")
+//	void testCommandTimehandlerHelp_ServerArgs_1() {
+//		boolean condition;
+//		String label = "timehandler";
+//		String[] args = {"help"};
+//		Command command = server.getPluginCommand(label);
+//
+//		assert command != null;
+//		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
+//
+//		assertTrue(condition);
+//	}
 
 	/* ==== TEST /TIMEHANDLER INFO ==== */
 	@Test
 	void testCommandTimehandlerInfo_PlayerArgs_1() {
-		boolean condition = false;
+		boolean condition;
 		String label = "timehandler";
 		Command command = server.getPluginCommand(label);
 		PlayerMock pMock = new PlayerMock(server, "player");
-		String args[] = {"info"};
-		
+		String[] args = {"info"};
+
+		assert command != null;
 		condition = timeHandler.onCommand(pMock, command, label, args);
 		
 		assertTrue(condition);
@@ -82,11 +79,12 @@ class CommandsTest {
 
 	@Test
 	void testCommandTimehandlerInfo_ServerArgs_1() {
-		boolean condition = false;
+		boolean condition;
 		String label = "timehandler";
-		String args[] = {"info"};
+		String[] args = {"info"};
 		Command command = server.getPluginCommand(label);
-		
+
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertFalse(condition);
@@ -94,11 +92,12 @@ class CommandsTest {
 
 	@Test
 	void testCommandTimehandlerInfo_ServerArgs_2() {
-		boolean condition = false;
+		boolean condition;
 		String label = "timehandler";
-		String args[] = {"info", "test"};
+		String[] args = {"info", "test"};
 		Command command = server.getPluginCommand(label);
-		
+
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertTrue(condition);
@@ -107,11 +106,12 @@ class CommandsTest {
 	/* ==== TEST /TIMEHANDLER LIST ==== */
 	@Test
 	void testCommandTimehandlerList_ServerArgs_1() {
-		boolean condition = false;
+		boolean condition;
 		String label = "timehandler";
-		String args[] = {"list"};
+		String[] args = {"list"};
 		Command command = server.getPluginCommand(label);
-		
+
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertTrue(condition);
@@ -119,11 +119,12 @@ class CommandsTest {
 
 	@Test
 	void testCommandTimehandlerList_ServerArgs_2() {
-		boolean condition = false;
+		boolean condition;
 		String label = "timehandler";
-		String args[] = {"list", "test"};
+		String[] args = {"list", "test"};
 		Command command = server.getPluginCommand(label);
-		
+
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertFalse(condition);
@@ -133,11 +134,12 @@ class CommandsTest {
 	@Test
 	@Order(1)
 	void testCommandTimehandlerSet_ServerArgs_2() {
-		boolean condition = false;
+		boolean condition;
 		String label = "timehandler";
-		String args[] = {"set", "test"};
+		String[] args = {"set", "test"};
 		Command command = server.getPluginCommand(label);
-		
+
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertTrue(condition);
@@ -145,11 +147,12 @@ class CommandsTest {
 
 	@Test
 	void testCommandTimehandlerSet_ServerArgs_4() {
-		boolean condition = false;
+		boolean condition;
 		String label = "timehandler";
-		String args[] = {"set", "test", "enabled", "false"};
+		String[] args = {"set", "test", "enabled", "false"};
 		Command command = server.getPluginCommand(label);
-		
+
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertTrue(condition);
@@ -162,11 +165,12 @@ class CommandsTest {
 
 	@Test
 	void testCommandTimehandlerSet_ServerArgs_3() {
-		boolean condition = false;
+		boolean condition;
 		String label = "timehandler";
-		String args[] = {"set", "test", "enabled"};
+		String[] args = {"set", "test", "enabled"};
 		Command command = server.getPluginCommand(label);
-		
+
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertFalse(condition);
@@ -175,11 +179,12 @@ class CommandsTest {
 	/* ==== TEST /TIMEHANDLER UPDATE ==== */
 	@Test
 	void testCommandTimehandlerUpdate_ServerArgs_0() {
-		boolean condition = false;
+		boolean condition;
 		String label = "timehandler";
-		String args[] = {"update"};
+		String[] args = {"update"};
 		Command command = server.getPluginCommand(label);
 		
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertTrue(condition);
@@ -188,11 +193,12 @@ class CommandsTest {
 	/* ==== TEST /TIMEHANDLER ANYTHING ==== */
 	@Test
 	void testCommandTimehandlerAnything_ServerArgs_0() {
-		boolean condition = false;
+		boolean condition;
 		String label = "timehandler";
-		String args[] = {"testErro"};
+		String[] args = {"testErro"};
 		Command command = server.getPluginCommand(label);
 		
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertFalse(condition);
@@ -201,11 +207,12 @@ class CommandsTest {
 	/* ==== TEST /DAY ==== */
 	@Test
 	void testCommandDay_ServerArgs_0() {
-		boolean condition = false;
+		boolean condition;
 		String label = "day";
-		String args[] = {};
+		String[] args = {};
 		Command command = server.getPluginCommand(label);
 		
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertFalse(condition);
@@ -213,15 +220,16 @@ class CommandsTest {
 
 	@Test
 	void testCommandDay_ServerArgs_1() {
-		boolean condition = false;
+		boolean condition;
 		String label = "day";
-		String args[] = {"test"};
+		String[] args = {"test"};
 		Command command = server.getPluginCommand(label);
 		
 		wMock.setTime(18000);
 
 		assertEquals(wMock.getTime(), 18000);
 		
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertTrue(condition);
@@ -230,9 +238,9 @@ class CommandsTest {
 
 	@Test
 	void testCommandDay_PlayerArgs_0() {
-		boolean condition = false;
+		boolean condition;
 		String label = "day";
-		String args[] = {};
+		String[] args = {};
 		Command command = server.getPluginCommand(label);
 		PlayerMock pMock = new PlayerMock(server, "player");
 		World world = pMock.getWorld();
@@ -241,6 +249,7 @@ class CommandsTest {
 
 		assertEquals(world.getTime(), 18000);
 		
+		assert command != null;
 		condition = timeHandler.onCommand(pMock, command, label, args);
 		
 		assertTrue(condition);
@@ -250,11 +259,12 @@ class CommandsTest {
 	/* ==== TEST /NIGHT ==== */
 	@Test
 	void testCommandNight_ServerArgs_0() {
-		boolean condition = false;
+		boolean condition;
 		String label = "night";
-		String args[] = {};
+		String[] args = {};
 		Command command = server.getPluginCommand(label);
 		
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertFalse(condition);
@@ -262,15 +272,16 @@ class CommandsTest {
 
 	@Test
 	void testCommandNight_ServerArgs_1() {
-		boolean condition = false;
+		boolean condition;
 		String label = "night";
-		String args[] = {"test"};
+		String[] args = {"test"};
 		Command command = server.getPluginCommand(label);
 		
 		wMock.setTime(6000);
 
 		assertEquals(wMock.getTime(), 6000);
 		
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertTrue(condition);
@@ -279,9 +290,9 @@ class CommandsTest {
 
 	@Test
 	void testCommandNight_PlayerArgs_0() {
-		boolean condition = false;
+		boolean condition;
 		String label = "night";
-		String args[] = {};
+		String[] args = {};
 		Command command = server.getPluginCommand(label);
 		PlayerMock pMock = new PlayerMock(server, "player");
 		World world = pMock.getWorld();
@@ -290,6 +301,7 @@ class CommandsTest {
 		
 		assertEquals(world.getTime(), 6000);
 		
+		assert command != null;
 		condition = timeHandler.onCommand(pMock, command, label, args);
 		
 		assertTrue(condition);
@@ -299,7 +311,7 @@ class CommandsTest {
 	/* ==== TEST /MOONPHASE ==== */
 	@Test
 	void testCommandMoonPhase_PlayerArgs_1() {
-		boolean condition = false;
+		boolean condition;
 		String label = "moonphase";
 		Set<String> phases = MoonPhasesEnum.getList();
 		Command command = server.getPluginCommand(label);
@@ -307,7 +319,8 @@ class CommandsTest {
 		World world = pMock.getWorld();
 
 		for(String p : phases) {
-			String args[] = {p};
+			String[] args = {p};
+			assert command != null;
 			condition = timeHandler.onCommand(pMock, command, label, args);
 			
 			if(MoonPhasesEnum.getEnumPorValue(p) == MoonPhasesEnum.DEFAULT) {
@@ -325,7 +338,8 @@ class CommandsTest {
 			assertEquals(expected, actual);
 		}
 
-		String aux[] = {"testeErro"};
+		String[] aux = {"testeErro"};
+		assert command != null;
 		condition = timeHandler.onCommand(pMock, command, label, aux);
 		assertFalse(condition);
 		
@@ -333,15 +347,16 @@ class CommandsTest {
 
 	@Test
 	void testCommandMoonPhase_ServerArgs_1() {
-		boolean condition = false;
+		boolean condition;
 		String label = "moonphase";
 		Command command = server.getPluginCommand(label);
 
-		String testeErro[] = {"testeErro"};
+		String[] testeErro = {"testeErro"};
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, testeErro);
 		assertFalse(condition);
 		
-		String testeTest[] = {"test"};
+		String[] testeTest = {"test"};
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, testeTest);
 		assertFalse(condition);
 		
@@ -349,13 +364,14 @@ class CommandsTest {
 
 	@Test
 	void testCommandMoonPhase_ServerArgs_2() {
-		boolean condition = false;
+		boolean condition;
 		String label = "moonphase";
 		Set<String> phases = MoonPhasesEnum.getList();
 		Command command = server.getPluginCommand(label);
 
 		for(String p : phases) {
-			String args[] = {p, "test"};
+			String[] args = {p, "test"};
+			assert command != null;
 			condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 			
 			if(MoonPhasesEnum.getEnumPorValue(p) == MoonPhasesEnum.DEFAULT) {
@@ -373,7 +389,8 @@ class CommandsTest {
 			assertEquals(expected, actual);
 		}
 
-		String aux[] = {"testeErro", "test"};
+		String[] aux = {"testeErro", "test"};
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, aux);
 		assertFalse(condition);
 		
@@ -382,9 +399,9 @@ class CommandsTest {
 	/* ==== TEST /RAIN ==== */
 	@Test
 	void testCommandRain_ServerArgs_0() {
-		boolean condition = false;
+		boolean condition;
 		String label = "rain";
-		String args[] = {};
+		String[] args = {};
 		Command command = server.getPluginCommand(label);
 		
 		wMock.setStorm(false);
@@ -392,7 +409,8 @@ class CommandsTest {
 		
 		assertFalse(wMock.hasStorm());
 		assertFalse(wMock.isThundering());
-		
+
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertFalse(condition);
@@ -400,9 +418,9 @@ class CommandsTest {
 
 	@Test
 	void testCommandRain_ServerArgs_1() {
-		boolean condition = false;
+		boolean condition;
 		String label = "rain";
-		String args[] = {"test"};
+		String[] args = {"test"};
 		Command command = server.getPluginCommand(label);
 
 		wMock.setStorm(false);
@@ -410,7 +428,8 @@ class CommandsTest {
 		
 		assertFalse(wMock.hasStorm());
 		assertFalse(wMock.isThundering());
-		
+
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertTrue(condition);
@@ -421,9 +440,9 @@ class CommandsTest {
 
 	@Test
 	void testCommandRain_ServerArgs_2() {
-		boolean condition = false;
+		boolean condition;
 		String label = "rain";
-		String args[] = {"test", "20000"};
+		String[] args = {"test", "20000"};
 		Command command = server.getPluginCommand(label);
 
 		wMock.setStorm(false);
@@ -431,21 +450,22 @@ class CommandsTest {
 		
 		assertFalse(wMock.hasStorm());
 		assertFalse(wMock.isThundering());
-		
+
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertTrue(condition);
 		
 		assertTrue(wMock.hasStorm());
-		assertTrue(wMock.getWeatherDuration() == 20000);
+		assertEquals(wMock.getWeatherDuration(), 20000);
 		assertFalse(wMock.isThundering());
 	}
 
 	@Test
 	void testCommandRain_PlayerArgs_0() {
-		boolean condition = false;
+		boolean condition;
 		String label = "rain";
-		String args[] = {};
+		String[] args = {};
 		Command command = server.getPluginCommand(label);
 		PlayerMock pMock = new PlayerMock(server, "player");
 		World world = pMock.getWorld();
@@ -455,7 +475,8 @@ class CommandsTest {
 		
 		assertFalse(world.hasStorm());
 		assertFalse(world.isThundering());
-		
+
+		assert command != null;
 		condition = timeHandler.onCommand(pMock, command, label, args);
 		
 		assertTrue(condition);
@@ -467,9 +488,9 @@ class CommandsTest {
 	/* ==== TEST /THUNDERING ==== */
 	@Test
 	void testCommandThundering_ServerArgs_0() {
-		boolean condition = false;
+		boolean condition;
 		String label = "thundering";
-		String args[] = {};
+		String[] args = {};
 		Command command = server.getPluginCommand(label);
 		
 		wMock.setStorm(false);
@@ -478,6 +499,7 @@ class CommandsTest {
 		assertFalse(wMock.hasStorm());
 		assertFalse(wMock.isThundering());
 		
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertFalse(condition);
@@ -485,9 +507,9 @@ class CommandsTest {
 
 	@Test
 	void testCommandThundering_ServerArgs_1() {
-		boolean condition = false;
+		boolean condition;
 		String label = "thundering";
-		String args[] = {"test"};
+		String[] args = {"test"};
 		Command command = server.getPluginCommand(label);
 
 		wMock.setStorm(false);
@@ -496,6 +518,7 @@ class CommandsTest {
 		assertFalse(wMock.hasStorm());
 		assertFalse(wMock.isThundering());
 		
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertTrue(condition);
@@ -506,9 +529,9 @@ class CommandsTest {
 
 	@Test
 	void testCommandThundering_ServerArgs_2() {
-		boolean condition = false;
+		boolean condition;
 		String label = "thundering";
-		String args[] = {"test", "15000"};
+		String[] args = {"test", "15000"};
 		Command command = server.getPluginCommand(label);
 
 		wMock.setStorm(false);
@@ -517,20 +540,21 @@ class CommandsTest {
 		assertFalse(wMock.hasStorm());
 		assertFalse(wMock.isThundering());
 		
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertTrue(condition);
 		
 		assertTrue(wMock.hasStorm());
 		assertTrue(wMock.isThundering());
-		assertTrue(wMock.getThunderDuration() == 15000);
+		assertEquals(wMock.getThunderDuration(), 15000);
 	}
 
 	@Test
 	void testCommandThundering_PlayerArgs_0() {
-		boolean condition = false;
+		boolean condition;
 		String label = "thundering";
-		String args[] = {};
+		String[] args = {};
 		Command command = server.getPluginCommand(label);
 		PlayerMock pMock = new PlayerMock(server, "player");
 		World world = pMock.getWorld();
@@ -541,6 +565,7 @@ class CommandsTest {
 		assertFalse(world.hasStorm());
 		assertFalse(world.isThundering());
 		
+		assert command != null;
 		condition = timeHandler.onCommand(pMock, command, label, args);
 		
 		assertTrue(condition);
@@ -552,9 +577,9 @@ class CommandsTest {
 	/* ==== TEST /CALM ==== */
 	@Test
 	void testCommandCalm_ServerArgs_0() {
-		boolean condition = false;
+		boolean condition;
 		String label = "calm";
-		String args[] = {};
+		String[] args = {};
 		Command command = server.getPluginCommand(label);
 		
 		wMock.setStorm(true);
@@ -563,6 +588,7 @@ class CommandsTest {
 		assertTrue(wMock.hasStorm());
 		assertTrue(wMock.isThundering());
 		
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertFalse(condition);
@@ -570,9 +596,9 @@ class CommandsTest {
 
 	@Test
 	void testCommandCalm_ServerArgs_1() {
-		boolean condition = false;
+		boolean condition;
 		String label = "calm";
-		String args[] = {"test"};
+		String[] args = {"test"};
 		Command command = server.getPluginCommand(label);
 
 		wMock.setStorm(true);
@@ -581,6 +607,7 @@ class CommandsTest {
 		assertTrue(wMock.hasStorm());
 		assertTrue(wMock.isThundering());
 		
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertTrue(condition);
@@ -591,9 +618,9 @@ class CommandsTest {
 
 	@Test
 	void testCommandCalm_ServerArgs_2() {
-		boolean condition = false;
+		boolean condition;
 		String label = "calm";
-		String args[] = {"test", "30000"};
+		String[] args = {"test", "30000"};
 		Command command = server.getPluginCommand(label);
 
 		wMock.setStorm(true);
@@ -602,20 +629,21 @@ class CommandsTest {
 		assertTrue(wMock.hasStorm());
 		assertTrue(wMock.isThundering());
 		
+		assert command != null;
 		condition = timeHandler.onCommand(server.getConsoleSender(), command, label, args);
 		
 		assertTrue(condition);
 
 		assertFalse(wMock.hasStorm());
 		assertFalse(wMock.isThundering());
-		assertTrue(wMock.getWeatherDuration() == 30000);
+		assertEquals(wMock.getWeatherDuration(), 30000);
 	}
 
 	@Test
 	void testCommandCalm_PlayerArgs_0() {
-		boolean condition = false;
+		boolean condition;
 		String label = "calm";
-		String args[] = {};
+		String[] args = {};
 		Command command = server.getPluginCommand(label);
 		PlayerMock pMock = new PlayerMock(server, "player");
 		World world = pMock.getWorld();
@@ -626,6 +654,7 @@ class CommandsTest {
 		assertTrue(wMock.hasStorm());
 		assertTrue(wMock.isThundering());
 		
+		assert command != null;
 		condition = timeHandler.onCommand(pMock, command, label, args);
 		
 		assertTrue(condition);

--- a/src/test/java/me/reratos/timehandler/custom/PlayerMockCustom.java
+++ b/src/test/java/me/reratos/timehandler/custom/PlayerMockCustom.java
@@ -1,0 +1,43 @@
+package me.reratos.timehandler.custom;
+
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+
+import java.util.UUID;
+
+public class PlayerMockCustom extends PlayerMock {
+    private boolean sleeping = false;
+    private int sleepTicks = 0;
+
+    public PlayerMockCustom(ServerMock server, String name) {
+        super(server, name);
+    }
+
+    public PlayerMockCustom(ServerMock server, String name, UUID uuid) {
+        super(server, name, uuid);
+    }
+
+    public void setSleepTicks(int sleepTicks) {
+        if(sleepTicks > 100) {
+            this.sleepTicks = 100;
+        } else if(sleepTicks < 0) {
+            this.sleepTicks = 0;
+        } else {
+            this.sleepTicks = sleepTicks;
+        }
+    }
+
+    public void setSleeping(boolean sleeping) {
+        this.sleeping = sleeping;
+    }
+
+    @Override
+    public boolean isSleeping() {
+        return this.sleeping;
+    }
+
+    @Override
+    public int getSleepTicks() {
+        return this.sleepTicks;
+    }
+}

--- a/src/test/java/me/reratos/timehandler/events/PlayerListenerTest.java
+++ b/src/test/java/me/reratos/timehandler/events/PlayerListenerTest.java
@@ -1,0 +1,152 @@
+package me.reratos.timehandler.events;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.WorldMock;
+import be.seeseemelk.mockbukkit.block.BlockMock;
+import be.seeseemelk.mockbukkit.scheduler.AsyncTaskException;
+import me.reratos.timehandler.TimeHandler;
+import me.reratos.timehandler.custom.PlayerMockCustom;
+import me.reratos.timehandler.handler.CommandHandler;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.player.PlayerBedLeaveEvent;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PlayerListenerTest {
+
+    private static ServerMock serverMock;
+    private static TimeHandler timeHandler;
+    public static WorldMock worldMock;
+    public static PlayerMockCustom playerMockCustom;
+    public static PlayerListener playerListener;
+
+    @BeforeAll
+    public static void setUp() {
+        serverMock = MockBukkit.mock();
+        timeHandler = MockBukkit.load(TimeHandler.class);
+        playerListener = new PlayerListener();
+
+        // configurando mundo
+        worldMock = new WorldMock();
+        worldMock.setName("world_test_1");
+
+        serverMock.addWorld(worldMock);
+
+        //configure world in the plugin
+        CommandHandler.set(serverMock.getConsoleSender(), worldMock.getName());
+        CommandHandler.set(serverMock.getConsoleSender(), worldMock.getName(), "time", "configured");
+        CommandHandler.set(serverMock.getConsoleSender(), worldMock.getName(), "durationDay", "28000");
+        CommandHandler.set(serverMock.getConsoleSender(), worldMock.getName(), "durationNight", "20000");
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        try {
+            MockBukkit.unmock();
+        } catch (AsyncTaskException ignored) {
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        playerMockCustom = new PlayerMockCustom(serverMock, "Player_test_1");
+
+        //reset players for next test
+        serverMock.setPlayers(0);
+        serverMock.addPlayer(playerMockCustom);
+
+        //set time to night 20000 ticks
+        worldMock.setTime(20000);
+    }
+
+    @Test
+    public void testOnPlayerBedLeaveEventWhen1PlayerSleepTicks100() {
+        List<PlayerMockCustom> listPlayers = (List<PlayerMockCustom>) serverMock.getOnlinePlayers();
+
+        assertEquals(1, listPlayers.size());
+
+        PlayerMockCustom player_1 = (PlayerMockCustom) listPlayers.get(0);
+        player_1.setSleeping(true);
+        player_1.setSleepTicks(100);
+
+        Block bedBlue = new BlockMock(Material.BLUE_BED);
+        PlayerBedLeaveEvent playerBedLeaveEvent = new PlayerBedLeaveEvent(player_1, bedBlue, false);
+
+        playerListener.onPlayerBedLeaveEvent(playerBedLeaveEvent);
+
+        assertTrue(worldMock.getTime() < 20000);
+    }
+
+    @Test
+    public void testOnPlayerBedLeaveEventWhen1PlayerSleepTicksLess100() {
+        List<PlayerMockCustom> listPlayers = (List<PlayerMockCustom>) serverMock.getOnlinePlayers();
+
+        assertEquals(1, listPlayers.size());
+
+        PlayerMockCustom player_1 = (PlayerMockCustom) listPlayers.get(0);
+        player_1.setSleeping(true);
+        player_1.setSleepTicks(50);
+
+        Block bedBlue = new BlockMock(Material.BLUE_BED);
+        PlayerBedLeaveEvent playerBedLeaveEvent = new PlayerBedLeaveEvent(player_1, bedBlue, false);
+
+        playerListener.onPlayerBedLeaveEvent(playerBedLeaveEvent);
+
+        assertFalse(worldMock.getTime() < 20000);
+    }
+
+    @Test
+    public void testOnPlayerBedLeaveEventWhen2PlayersSleepTicks100() {
+        PlayerMockCustom playerMockCustom2 = new PlayerMockCustom(serverMock, "Player_test_2");
+        serverMock.addPlayer(playerMockCustom2);
+
+        List<PlayerMockCustom> listPlayers = (List<PlayerMockCustom>) serverMock.getOnlinePlayers();
+
+        assertTrue(listPlayers.size() > 1);
+
+        for(PlayerMockCustom pmc : listPlayers) {
+            pmc.setSleeping(true);
+            pmc.setSleepTicks(100);
+        }
+
+        PlayerMockCustom player_1 = listPlayers.get(0);
+
+        Block bedBlue = new BlockMock(Material.BLUE_BED);
+        PlayerBedLeaveEvent playerBedLeaveEvent = new PlayerBedLeaveEvent(player_1, bedBlue, false);
+
+        playerListener.onPlayerBedLeaveEvent(playerBedLeaveEvent);
+
+        assertTrue(worldMock.getTime() < 20000);
+    }
+
+    @Test
+    public void testOnPlayerBedLeaveEventWhen1PlayersSleepTicks100AndAnotherPlayerNot() {
+        PlayerMockCustom playerMockCustom2 = new PlayerMockCustom(serverMock, "Player_test_2");
+        serverMock.addPlayer(playerMockCustom2);
+
+        List<PlayerMockCustom> listPlayers = (List<PlayerMockCustom>) serverMock.getOnlinePlayers();
+
+        // deve conter mais de um player no servidor
+        assertTrue(listPlayers.size() > 1);
+
+        PlayerMockCustom player_1 = listPlayers.get(0);
+        player_1.setSleeping(true);
+        player_1.setSleepTicks(100);
+
+        Block bedBlue = new BlockMock(Material.BLUE_BED);
+        PlayerBedLeaveEvent playerBedLeaveEvent = new PlayerBedLeaveEvent(player_1, bedBlue, false);
+
+        playerListener.onPlayerBedLeaveEvent(playerBedLeaveEvent);
+
+        assertFalse(worldMock.getTime() < 20000);
+    }
+
+}

--- a/src/test/java/me/reratos/timehandler/handler/commands/SetCommandsTest.java
+++ b/src/test/java/me/reratos/timehandler/handler/commands/SetCommandsTest.java
@@ -28,7 +28,6 @@ import me.reratos.timehandler.utils.ConstantsWorldsConfig;
 class SetCommandsTest {
 	
 	private static ServerMock server;
-	private static WorldMock wMock;
 	private static WorldManager worldManager;
 //	private static TimeHandler timeHandler;
 	
@@ -37,8 +36,8 @@ class SetCommandsTest {
 	    server = MockBukkit.mock();
 //	    timeHandler = MockBukkit.load(TimeHandler.class);
 	    MockBukkit.load(TimeHandler.class);
-	    
-	    wMock = new WorldMock();
+
+		WorldMock wMock = new WorldMock();
 	    wMock.setName("test");
 	    
 	    server.addWorld(wMock);
@@ -49,8 +48,7 @@ class SetCommandsTest {
 	public static void tearDown() {
 		try {
 			MockBukkit.unmock();
-		} catch (AsyncTaskException e) {
-			// TODO: handle exception
+		} catch (AsyncTaskException ignored) {
 		}
 	}
 	
@@ -64,7 +62,7 @@ class SetCommandsTest {
 
 	@Test
 	void testCommandSetBase() {
-		boolean condition = false;
+		boolean condition;
 		Field[] fields = null;
 		
 		// Recupera os campos da classe ConstantsWorldsConfig
@@ -83,12 +81,12 @@ class SetCommandsTest {
 			String fieldValue;
 			
 			try {
-				fieldValue = (String) f.get((Object)f);
+				fieldValue = (String) f.get(f);
 				
 				condition = SetCommand.commandSetBase(server.getConsoleSender(), worldManager, fieldValue, "");
 				
 				assertTrue(condition);
-			} catch (Exception e) {
+			} catch (Exception ignored) {
 			}
 		}
 		
@@ -107,7 +105,7 @@ class SetCommandsTest {
 
 	@Test
 	void testCommandSetTime() {
-		boolean condition = false;
+		boolean condition;
 		Set<String> times = TimeEnum.getList();
 
 		// testando com todos os valores do enum TIME
@@ -127,7 +125,7 @@ class SetCommandsTest {
 
 	@Test
 	void testCommandSetTimeFixed() {
-		boolean condition = false;
+		boolean condition;
 		
 		// testando valor não numerico
 		condition = SetCommand.commandSetTimeFixed(server.getConsoleSender(), worldManager,  
@@ -156,7 +154,7 @@ class SetCommandsTest {
 
 	@Test
 	void testCommandSetDurationDay() {
-		boolean condition = false;
+		boolean condition;
 		
 		// menor que o minimos - false
 		condition = SetCommand.commandSetDurationDay(server.getConsoleSender(), worldManager, 
@@ -179,7 +177,7 @@ class SetCommandsTest {
 
 	@Test
 	void testCommandSetDurationNight() {
-		boolean condition = false;
+		boolean condition;
 		
 		// menor que o minimos - false
 		condition = SetCommand.commandSetDurationNight(server.getConsoleSender(), worldManager, 
@@ -202,7 +200,7 @@ class SetCommandsTest {
 
 	@Test
 	void testCommandSetMoonPhase() {
-		boolean condition = false;
+		boolean condition;
 		
 		Set<String> set = MoonPhasesEnum.getList();
 
@@ -223,7 +221,7 @@ class SetCommandsTest {
 
 	@Test
 	void testCommandSetThunder() {
-		boolean condition = false;
+		boolean condition;
 		
 		Set<String> set = ThunderEnum.getList();
 
@@ -244,7 +242,7 @@ class SetCommandsTest {
 
 	@Test
 	void testCommandSetWeather() {
-		boolean condition = false;
+		boolean condition;
 		
 		Set<String> set = WeatherEnum.getList();
 		
@@ -265,7 +263,7 @@ class SetCommandsTest {
 
 	@Test
 	void testCommandSetEnabled() {
-		boolean condition = false;
+		boolean condition;
 
 		// testando com valor falso
 		condition = SetCommand.commandSetEnabled(server.getConsoleSender(), worldManager, 

--- a/src/test/java/me/reratos/timehandler/utils/LocaleLoaderTest.java
+++ b/src/test/java/me/reratos/timehandler/utils/LocaleLoaderTest.java
@@ -61,7 +61,7 @@ class LocaleLoaderTest {
 			
 			try {
 				fieldName = f.getName();
-				fieldValue = (String) f.get((Object)f);
+				fieldValue = (String) f.get(f);
 				
 				String message = LocaleLoader.getString(fieldValue);
 				
@@ -85,7 +85,7 @@ class LocaleLoaderTest {
 		Properties properties = new Properties();
 		Field[] fields = null;
 		File file = new File("src/main/resources/lang/locale.properties");
-		FileInputStream fis = null;
+		FileInputStream fis;
 		List<String> listValueField = new ArrayList<>();
 		List<String> listValueKey = new ArrayList<>();
 


### PR DESCRIPTION
- Inserido a monitoração pelo bStatus/Metrics para verificar melhor em quais versões o plugin é mais utilizado, afim de solucionar bugs mais rapidamente.
- Criada a Classe PlayerMockCustom com a intenção de manipular os atributos de sleep para teste unitarios.
- Criada a classe de teste unitario/integrado PlayerListenerTest para validar o bug onde não ocorria o skip night no servidor após todos os players dormirem.